### PR TITLE
Fix url reverse for dashboard

### DIFF
--- a/oscar_promotions/dashboard/apps.py
+++ b/oscar_promotions/dashboard/apps.py
@@ -8,6 +8,7 @@ class PromotionsDashboardConfig(OscarDashboardConfig):
 
     label = 'oscar_promotions_dashboard'
     name = 'oscar_promotions.dashboard'
+    namespace = 'oscar_promotions_dashboard'
     verbose_name = _("Promotions dashboard")
     default_permissions = ['is_staff']
 


### PR DESCRIPTION
Whitout the `namespace` I got the error `NoReverseMatch: Reverse for 'promotion-list-by-page' not found`, once I add the namespace it works properly for adding the url to the dashboard