### PR TITLE
fix reverse url and add a minus to page url to avoid url rewrites

### DIFF
--- a/oscar_promotions/dashboard/apps.py
+++ b/oscar_promotions/dashboard/apps.py
@@ -55,7 +55,7 @@ class PromotionsDashboardConfig(OscarDashboardConfig):
             url(r'^$', self.list_view.as_view(), name='promotion-list'),
             url(r'^pages/$', self.page_list.as_view(), name='promotion-list-by-page'),
             url(
-                r'^page/(?P<path>/([\w-]+(/[\w-]+)*/)?)$',
+                r'^page/-(?P<path>/([\w-]+(/[\w-]+)*/)?)$',
                 self.page_detail.as_view(),
                 name='promotion-list-by-url',
             ),

--- a/oscar_promotions/templates/oscar_promotions/dashboard/page_detail.html
+++ b/oscar_promotions/templates/oscar_promotions/dashboard/page_detail.html
@@ -39,7 +39,7 @@
                 <tbody class="promotion_list">
                     {% for promotion in position.promotions %}
                         <tr id="promo_{{ promotion.pk }}">
-                            <td><a href="{% url 'oscar_promotions_dashboard:promotion-update' ptype=promotion.content_object.code pk=promotion.pk %}">{{ promotion.content_object.name }}</a></td>
+                            <td><a href="{% url 'oscar_promotions_dashboard:promotion-update' ptype=promotion.content_object.code pk=promotion.content_object.pk %}">{{ promotion.content_object.name }}</a></td>
                             <td>{{ promotion.content_object.type }}</td>
                             <td>
                                 <div class="btn-toolbar">


### PR DESCRIPTION
In apache2 the url was merged due of double slash, I tried different rewrites and nothing worked, so in order to save some time to other people, I added a slash to the url patter for editing the page promotion.

before:
```
/dashboard/promotions/page//
/dashboard/promotions/page//contact
```
now:
```
/dashboard/promotions/page/-/
/dashboard/promotions/page/-/contact
```
